### PR TITLE
Add intro block with personal introduction and SVG icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,31 @@
           </div>
         </div>
       </div>
+      <div class="container">
+        <div class="resume__block">
+          <div class="intro">
+            <div class="intro__icon-wrapper">
+              <svg class="intro__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+                <path
+                  d="M464 256h-80v-64c0-35.3 28.7-64 64-64h8c13.3 0 24-10.7
+                  24-24V56c0-13.3-10.7-24-24-24h-8c-88.4 0-160 71.6-160 160v240c0
+                  26.5 21.5 48 48 48h128c26.5 0 48-21.5
+                  48-48V304c0-26.5-21.5-48-48-48zm-288 0H96v-64c0-35.3 28.7-64
+                  64-64h8c13.3 0 24-10.7 24-24V56c0-13.3-10.7-24-24-24h-8C71.6 32 0
+                  103.6 0 192v240c0 26.5 21.5 48 48 48h128c26.5 0
+                  48-21.5 48-48V304c0-26.5-21.5-48-48-48z"
+                ></path>
+              </svg>
+            </div>
+            <p class="intro_text">I am Olena a meticulous and detail-oriented professional
+               driven by a dedication to mastering the field of software testing. I am proficient
+               in QA fundamentals, diverse software testing tools, and methodologies. I am a critical 
+               thinker and effective problem solver, showcasing robust teamwork, communication, 
+               and organisational skills. 
+              </p>
+          </div>
+        </div>
+      </div>
     </main>
   </body>
 </html>


### PR DESCRIPTION
This pull request adds the intro block below the contact info section. The intro block includes a personal introduction and an SVG icon. Changes Made
- Added a new container with the class `intro` below the contact information container.
- Included an SVG icon and a paragraph with a brief introduction.